### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains a Model Context Protocol server implementation for Dev.to that allows AI assistants to access and interact with Dev.to content.
 
+<a href="https://glama.ai/mcp/servers/@Arindam200/devto-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Arindam200/devto-mcp/badge" alt="Dev.to Server MCP server" />
+</a>
+
 ![image](./Demo.png)
 
 ## What is MCP?


### PR DESCRIPTION
This PR adds a badge for the [Dev.to MCP Server](https://glama.ai/mcp/servers/@Arindam200/devto-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Arindam200/devto-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Arindam200/devto-mcp/badge" alt="Dev.to Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.